### PR TITLE
Add enums for product dimension units

### DIFF
--- a/smallbiznis/product/product.proto
+++ b/smallbiznis/product/product.proto
@@ -8,7 +8,6 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/api/annotations.proto";
-import "google/type/money.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 import "smallbiznis/common/pagination.proto";
 
@@ -33,6 +32,14 @@ enum WeightUnit {
   UNIT_UNSPECIFIED = 0;
   KG = 1;
   G = 2;
+}
+
+enum HeightUnit {
+  HEIGHT_UNIT_UNSPECIFIED = 0;
+  M = 1;
+  CM = 2;
+  IN = 3;
+  FT = 4;
 }
 
 // ----------------------------
@@ -120,9 +127,9 @@ message Dimension {
   string dimension_id = 1;
   string variant_id = 2;
   double weight = 3;
-  string weight_unit = 4;
+  WeightUnit weight_unit = 4;
   double height = 5;
-  string height_unit = 6;
+  HeightUnit height_unit = 6;
   double depth = 7;
 }
 


### PR DESCRIPTION
## Summary
- introduce a height unit enum and wire it into product variant dimensions
- reuse the existing weight unit enum in dimension definitions
- remove the unused google.type.Money import from the product proto file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dde98954ac83268ade0df0a295da72