### PR TITLE
feat: add variant stock event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # Smallbiznis APIs
+
+## Variant stock event streaming
+
+Realtime inventory updates are now exposed through the
+`VariantStockEventService.SubscribeVariantStock` server-side stream. The gRPC
+stream is bridged to HTTP via the gateway so that admin clients can establish
+an SSE connection using the following endpoint:
+
+```
+GET /api/v1/orgs/{org_id}/variant-stock:subscribe
+```
+
+Query parameters can be used to filter specific variant or location IDs
+(`variant_ids` and `location_ids`) and to resume from a cursor. When the
+`include_snapshot` flag is provided, the first message includes the current
+`VariantStock` state before live deltas are pushed.
+
+Every successful stock mutation (`UpdateVariantStock`, `AdjustInventory`, and
+`TransferInventory`) publishes a `VariantStockEvent`. Event payloads contain
+the delta quantities, the latest stock snapshot, and metadata such as
+`event_type`, `occurred_at`, and `correlation_id` so consumers can reconcile
+state changes.

--- a/smallbiznis/inventory/inventory.proto
+++ b/smallbiznis/inventory/inventory.proto
@@ -180,7 +180,8 @@ service InventoryService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Inventory" summary: "Transfer an inventory" operation_id: "Inventory_Transfer";
+      tags: "Inventory" summary: "Transfer an inventory" operation_id: "Inventory_Transfer"
+      description: "Transfers inventory between locations and publishes VariantStockEvent updates for both locations."
     };
   }
 
@@ -190,7 +191,8 @@ service InventoryService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Inventory" summary: "Adjust an inventory" operation_id: "Inventory_Adjust";
+      tags: "Inventory" summary: "Adjust an inventory" operation_id: "Inventory_Adjust"
+      description: "Adjusts inventory quantities and publishes a VariantStockEvent for downstream subscribers."
     };
   }
 

--- a/smallbiznis/product/product.proto
+++ b/smallbiznis/product/product.proto
@@ -494,5 +494,16 @@ service ProductService {
     };
   }
 
-  rpc UpdateVariantStock(UpdateVariantStockRequest) returns (VariantStock);
+  rpc UpdateVariantStock(UpdateVariantStockRequest) returns (VariantStock) {
+    option (google.api.http) = {
+      put: "/v1/orgs/{org_id}/variants/{variant_id}/locations/{location_id}/stock"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Variants"
+      summary: "Update variant stock"
+      operation_id: "VariantStock_Update"
+      description: "Updates variant stock levels and publishes a VariantStockEvent on success."
+    };
+  }
 }

--- a/smallbiznis/product/product_events.proto
+++ b/smallbiznis/product/product_events.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package smallbiznis.product.v1;
+
+option go_package = "github.com/smallbiznis/go-genproto/smallbiznis/product/v1;productv1";
+
+import "google/protobuf/timestamp.proto";
+import "google/api/annotations.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
+import "smallbiznis/product/product.proto";
+
+// VariantStockEventType enumerates the types of stock related changes that can
+// be delivered to subscribers.
+enum VariantStockEventType {
+  VARIANT_STOCK_EVENT_TYPE_UNSPECIFIED = 0;
+  VARIANT_STOCK_UPDATED = 1;
+  VARIANT_STOCK_ADJUSTED = 2;
+  VARIANT_STOCK_TRANSFERRED = 3;
+}
+
+// VariantStockEvent captures the inventory state of a variant at the time an
+// update, adjustment, or transfer completed successfully.
+message VariantStockEvent {
+  string event_id = 1;
+  VariantStockEventType event_type = 2;
+  string org_id = 3;
+  string variant_id = 4;
+  string location_id = 5;
+  int32 delta_on_hand_quantity = 6;
+  int32 delta_reserved_quantity = 7;
+  VariantStock stock_snapshot = 8;
+  google.protobuf.Timestamp occurred_at = 9;
+  string correlation_id = 10;
+  string triggered_by = 11;
+}
+
+// SubscribeVariantStockRequest defines filters and resume tokens that can be
+// used when establishing a streaming subscription.
+message SubscribeVariantStockRequest {
+  string org_id = 1;
+  repeated string variant_ids = 2;
+  repeated string location_ids = 3;
+  string cursor = 4;
+  bool include_snapshot = 5;
+}
+
+service VariantStockEventService {
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {
+    name: "Variant Stock Events"
+    description: "Realtime notifications for variant stock movements"
+  };
+
+  // SubscribeVariantStock opens a server side stream that emits VariantStockEvent
+  // payloads. The HTTP binding enables the gateway to expose the stream as
+  // Server-Sent Events (SSE) or WebSockets for admin web clients.
+  rpc SubscribeVariantStock(SubscribeVariantStockRequest) returns (stream VariantStockEvent) {
+    option (google.api.http) = {
+      get: "/v1/orgs/{org_id}/variant-stock:subscribe"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Variant Stock Events"
+      summary: "Subscribe to variant stock events"
+      operation_id: "VariantStock_Subscribe"
+      description: "Streams VariantStockEvent payloads for inventory updates, adjustments, and transfers."
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- introduce VariantStockEvent proto definitions and streaming service for inventory changes
- annotate stock mutation RPCs so downstream clients know events are emitted
- document the SSE subscription contract for admin clients

## Testing
- make openapi *(fails: google/protobuf/timestamp.proto not found in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e531fec6d48326946a28edeb741543